### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-#ReactiveCocoa, Swift and MVVM
+# ReactiveCocoa, Swift and MVVM
 
 This application is a Swift-port of an MVVM / ReactiveCocoa example application [I wrote a few months ago](https://github.com/ColinEberhardt/ReactiveFlickrSearch).
 
 ![image](FinishedApp.png)
 
-##Instructions
+## Instructions
 
 This project uses a combination of both CocoaPods and git submodules. The reason for this is that the current version of ReactiveCocoa is not compatible with Swift, as [detailed in this blog post](http://www.scottlogic.com/blog/2014/07/24/mvvm-reactivecocoa-swift.html).
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
